### PR TITLE
Map Offline => Off

### DIFF
--- a/LitterRobot/Managers/SourceManager.cs
+++ b/LitterRobot/Managers/SourceManager.cs
@@ -80,6 +80,7 @@ namespace LitterRobot.Managers
         {
             { "RDY", "Ready" },
             { "OFF", "Off" },
+            { "OFFLINE", "Off" },
             { "P",   "Paused" },
             { "BR",  "Bonnet removed" },
             { "DFS", "Drawer full" },


### PR DESCRIPTION
When the Litter Robot is off, sometimes the API reports "OFFLINE" as the
status. It's unclear to me what the pattern really is or if there is
anything meaningful to be gleaned from the Offline status.

For the moment, I'm going to treat it as Off -- since that's the only
time it seems to happen.